### PR TITLE
Add theory detail in neural network readmes

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,11 +49,13 @@ Each section contains subdirectories for specific templates, along with a README
 
 ### General Purpose Scripts
 
-In the general directory, you'll find templates for everyday programming tasks that can help you automate workflows, process data, and more. Examples include:
+In the `general` directory, you'll find templates for everyday programming tasks that can help you automate workflows, process data, and more. Examples include:
 
 * CSV file manipulation
 * Web scraping
 * Batch renaming of files
+* Utility helpers for setting random seeds, downloading files and timing code
+* Common DataFrame operations and visualisation helpers
 
 ### Machine Learning Templates
 The machine_learning directory offers templates for various components of machine learning projects, including:
@@ -66,8 +68,11 @@ The machine_learning directory offers templates for various components of machin
 ### Deep Learning Templates
 Our deep_learning section includes templates designed for neural network projects, with examples for:
 
-* Convolutional Neural Networks (CNNs) for image classification
-* Recurrent Neural Networks (RNNs) for time series analysis
+* Convolutional Neural Networks (CNNs) including simple ResNet examples
+* Recurrent Neural Networks (RNNs, LSTMs, and GRUs) for sequence modeling
+* Transformer utilities for working with large language models and fine-tuning
+* Graph Neural Networks (GCN, GAT, and GraphSAGE layers)
+* Reinforcement learning helpers from Q-learning to DQN
 * Generative Adversarial Networks (GANs) for image generation
 
 ### How to Use the Templates

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ In the `general` directory, you'll find templates for everyday programming tasks
 * Web scraping
 * Batch renaming of files
 * Utility helpers for setting random seeds, downloading files and timing code
-* Common DataFrame operations and visualisation helpers
+* Common DataFrame operations and visualization helpers
 
 ### Machine Learning Templates
 The machine_learning directory offers templates for various components of machine learning projects, including:

--- a/deep_learning/README_PyTorch.md
+++ b/deep_learning/README_PyTorch.md
@@ -1,0 +1,30 @@
+# PyTorch.py
+
+This script presents a minimal example of constructing a feed-forward network for tabular data using the PyTorch
+framework. The code defines a `TabularModel` class derived from `nn.Module` and demonstrates how to initialize and use
+it.
+
+## Model Architecture
+
+- The constructor builds a sequence of `nn.Linear` layers separated by `nn.ReLU` activations. Layer sizes are provided
+  via the `hidden_layers` list.
+- The `forward` method defines how inputs flow through these layers.
+
+## Python Features
+
+PyTorch modules subclass `nn.Module` and must implement a `forward` method. The use of `nn.Sequential` collects layers
+into a single callable block. Comprehensions are used to dynamically create intermediate layers.
+
+## Theory
+
+Neural networks learn nonlinear mappings from inputs to outputs by composing linear transformations and non-linear
+activation functions. Here we demonstrate a simple fully connected architecture suitable for tabular regression or
+classification tasks. During training, PyTorch uses automatic differentiation to compute gradients for backpropagation.
+
+At its core, PyTorch represents models as dynamic computation graphs. This means
+the graph is defined on-the-fly as tensors flow through operations, making it
+easy to debug and allowing for flexible model architectures. Each parameter is a
+tensor with attached gradients, and optimizers adjust these parameters by
+descending along the gradient of a loss function. This mechanism enables the
+iterative refinement of the network's weights so that predictions gradually
+improve on the training data.

--- a/deep_learning/README_Tensorflow.md
+++ b/deep_learning/README_Tensorflow.md
@@ -1,0 +1,32 @@
+# Tensorflow.py
+
+This file collects two TensorFlow examples: a dense network for tabular data and a simple convolutional neural network.
+
+## Dense Model
+
+`create_model` builds a sequential stack of `Dense` layers. Activation functions are referenced by name from
+`tensorflow.keras.activations`. The script shows how to compile the model for regression (MSE loss) or classification
+(using e.g., `binary_crossentropy`).
+
+Training is performed with `model.fit`, where the resulting `history` object records metrics over epochs.
+
+## CNN Example
+
+`create_cnn_model` constructs a tiny CNN with convolutional and pooling layers followed by dense layers. After
+compiling, the model is trained on image data and evaluated on a test set. The placeholders in the code indicate where
+you would load your own dataset.
+
+## Theory
+
+Dense layers perform affine transformations followed by nonlinear activations, suitable for structured data. Convolution
+layers slide learnable filters over images to detect features, while pooling layers downsample to reduce spatial
+resolution. Dropout randomly zeros activations to mitigate overfitting. These building blocks underpin many modern
+computer vision models.
+
+TensorFlow builds static computation graphs that are optimized before execution.
+This allows for efficient deployment across different hardware backends but
+requires model structures to be defined up front. The Keras API offers a higher
+level abstraction where layers are composed to form a model object that can be
+compiled and trained with minimal code. Underneath, gradients are calculated via
+automatic differentiation, enabling the training of deep networks across a wide
+range of domains.

--- a/deep_learning/README_cnn_models.md
+++ b/deep_learning/README_cnn_models.md
@@ -1,0 +1,27 @@
+# cnn_models.py
+
+The module contains a tiny ResNet-style implementation using PyTorch. Residual blocks help train deep networks by
+allowing gradients to flow through skip connections.
+
+## Classes
+
+- **`ResidualBlock`** – consists of two convolutional layers with batch normalization. If the input and output shapes
+differ, a downsampling layer aligns them. The residual is then added back to the main path.
+- **`SimpleResNet`** – stacks two residual blocks and performs global average pooling before the final linear layer.
+
+## Python Details
+
+`nn.Module` subclasses require a `forward` method describing the computation. Tensor shapes are manipulated with
+`nn.Conv2d`, `nn.BatchNorm2d` and `nn.AdaptiveAvgPool2d`. Residual addition uses the `+=` operator for tensor addition.
+
+## Theory
+
+Residual networks mitigate the vanishing gradient problem by providing shortcut connections that carry information from
+earlier layers directly to later ones. This simple example demonstrates the pattern used in deeper architectures such as
+ResNet-50 and beyond.
+
+Deeper CNNs benefit from these residual paths because gradients can travel
+across many layers without vanishing or exploding. A residual block effectively
+learns only the residual mapping—the difference between its input and desired
+output—so optimization is easier. This principle supports very deep networks
+that capture hierarchical image features while remaining stable to train.

--- a/deep_learning/README_gan_models.md
+++ b/deep_learning/README_gan_models.md
@@ -1,0 +1,30 @@
+# gan_models.py
+
+This file defines a minimal Generative Adversarial Network (GAN) using PyTorch. GANs pit two neural networks—the
+Generator and the Discriminator—against each other in a game-theoretic setup.
+
+## Components
+
+- **`Generator`** – transforms random noise vectors into images via a series of linear layers with ReLU activations and
+a final `tanh` to scale outputs to [-1, 1].
+- **`Discriminator`** – takes images and attempts to classify them as real or fake using a small feed-forward network
+with LeakyReLU activations.
+
+## Python Aspects
+
+Both classes inherit from `nn.Module` and define a `forward` method. Sequential containers (`nn.Sequential`) make layer
+construction concise. The architecture is intentionally simple for instructional purposes.
+
+## Theory
+
+GANs train the generator to produce realistic samples that fool the discriminator, while simultaneously training the
+discriminator to correctly distinguish real from generated data. This adversarial process often leads to high-quality
+synthetic images once the two networks reach equilibrium.
+
+From a probabilistic perspective, the generator implicitly defines a model of the
+data distribution. The discriminator provides feedback by estimating how far the
+generated samples deviate from real examples. Training proceeds as a minimax
+game: the generator minimizes the discriminator's ability to tell real from
+fake, while the discriminator maximizes it. When this game converges, the
+generator approximates the true data distribution, producing convincing samples
+despite never seeing explicit probability densities.

--- a/deep_learning/README_gnn_models.md
+++ b/deep_learning/README_gnn_models.md
@@ -1,0 +1,35 @@
+# gnn_models.py
+
+This module provides simple graph neural network layers. Graph neural networks operate on data structured as nodes and
+edges, capturing relationships that traditional architectures cannot.
+
+## Layers
+
+- **`normalize_adjacency`** – computes a symmetrically normalized adjacency matrix. This step stabilizes graph
+  convolutions by scaling by node degrees.
+- **`GCNLayer`** – implements a basic graph convolution. Node features are propagated by multiplying with the normalized
+  adjacency matrix and passing through a linear transformation.
+- **`GATLayer`** – introduces attention on edges. Each node attends to its neighbours via learnable attention weights,
+  allowing the model to focus on the most relevant connections.
+- **`GraphSAGELayer`** – aggregates neighbourhood information using mean, sum, or max operations and concatenates it with
+  the node's own features.
+
+## Python Techniques
+
+All layers subclass `nn.Module`. Matrix operations use PyTorch tensor algebra, including `@` for matrix multiplication
+and `torch.einsum` in the attention layer. Parameters are registered via `nn.Parameter` so PyTorch tracks them during
+optimization.
+
+## Theoretical Motivation
+
+GCN layers approximate spectral convolutions on graphs, blending each node with its neighbours. GAT layers apply
+self-attention to learn importance weights. GraphSAGE samples and aggregates neighbourhoods, enabling scalable training
+on large graphs. These mechanisms empower models to learn from relational data such as social networks or molecular
+structures.
+
+The field of geometric deep learning frames these layers as extensions of
+convolution to non-Euclidean domains. By respecting the graph's connectivity,
+models capture complex relational patterns that regular CNNs cannot. Attention
+mechanisms like those in GAT further refine message passing by letting each node
+weight information from its neighbours according to their relevance for the
+prediction task.

--- a/deep_learning/README_reinforcement_learning.md
+++ b/deep_learning/README_reinforcement_learning.md
@@ -1,0 +1,31 @@
+# reinforcement_learning.py
+
+The reinforcement learning helpers demonstrate both tabular Q-learning and a minimal Deep Q-Network (DQN) using
+PyTorch. Reinforcement learning optimizes an agent's behaviour through trial and error interactions with an environment.
+
+## Functions and Classes
+
+- **`epsilon_greedy`** – selects an action from Q-values using an exploration parameter `epsilon`.
+- **`q_learning`** – implements classic Q-learning for environments with discrete states. It maintains a Q-table and
+  updates it using the Bellman equation.
+- **`DQN`** – a neural network that approximates the action-value function for environments with continuous states.
+- **`dqn_learning`** – trains the DQN on an environment using an epsilon-greedy policy and mean-squared error loss.
+
+## Python Notes
+
+The training loops rely on NumPy for array manipulations and PyTorch for tensor operations and optimization. The
+functions show how to interact with Gym-like environments by calling `env.reset()` and `env.step(action)`.
+
+## Theory
+
+Q-learning iteratively updates Q-values using the reward plus the discounted value of the best next state. Deep
+Q-Networks replace the lookup table with a neural network to handle large or continuous state spaces. Exploration via
+epsilon-greedy ensures the agent occasionally tries new actions. The combination of gradient-based updates and reward
+signals enables agents to learn control policies from experience.
+
+Viewed through the lens of dynamic programming, reinforcement learning seeks to
+approximate the optimal action-value function. Tabular methods update a lookup
+table directly, while DQNs parameterize this function with a neural network so
+that high-dimensional or continuous states can be tackled. The use of a discount
+factor encodes a preference for immediate rewards, and the exploration schedule
+balances gathering new experience versus exploiting current knowledge.

--- a/deep_learning/README_rnn_helpers.md
+++ b/deep_learning/README_rnn_helpers.md
@@ -1,0 +1,30 @@
+# rnn_helpers.py
+
+This module includes small PyTorch classes implementing different recurrent neural networks. RNNs are well-suited for
+processing sequential data such as text, audio or time series.
+
+## Classes
+
+- **`SimpleRNNModel`** – uses the basic `nn.RNN` layer. The final hidden state of the sequence feeds into a linear
+  layer to produce the output.
+- **`LSTMModel`** – employs an LSTM layer which keeps separate hidden and cell states, allowing the network to learn
+  longer-range dependencies.
+- **`GRUModel`** – similar to the LSTM but with a simplified gating mechanism. Useful when you want fewer parameters.
+
+## Syntax Points
+
+All models inherit from `nn.Module`. The `forward` methods return the output after processing the last time step. Batch
+first mode (`batch_first=True`) expects tensors shaped `(batch, seq, features)`.
+
+## Theory
+
+Recurrent networks maintain internal state across time steps. LSTMs and GRUs introduce gates that control information
+flow, mitigating the vanishing gradient problem and enabling the capture of long-term patterns. They are widely used in
+language modelling, speech recognition and other sequence prediction tasks.
+
+Classic RNNs struggle with long dependencies because repeated multiplications of
+the recurrent weight matrix shrink or explode gradients. LSTMs and GRUs address
+this by adding gating mechanisms that regulate how information enters, leaves and
+is forgotten from the cell state. These gates allow the network to maintain a
+stable memory over many time steps, making them effective for natural language
+and time series data where context matters.

--- a/deep_learning/README_transformer_helpers.md
+++ b/deep_learning/README_transformer_helpers.md
@@ -1,0 +1,32 @@
+# transformer_helpers.py
+
+The helpers in this file simplify common tasks when working with Hugging Face transformers for natural language
+processing.
+
+## Utilities
+
+- **`load_model_and_tokenizer`** – downloads a pretrained causal language model and its tokenizer.
+- **`generate_text`** – feeds a prompt into the model and returns the generated continuation. Uses PyTorch tensors under
+the hood.
+- **`text_generation_pipeline`** – convenience wrapper that constructs a pipeline object for immediate generation.
+- **`fine_tune_text_classification`** – shows how to fine-tune a transformer on a text classification task with the
+  `Trainer` API.
+
+## Python Syntax
+
+Transformers are loaded via class methods like `AutoModelForCausalLM.from_pretrained`. Data is tokenized with
+`tokenizer(prompt, return_tensors="pt")` to produce PyTorch tensors. The `TrainingArguments` class configures the
+details of training such as output directory and number of epochs.
+
+## Theory
+
+Transformer architectures rely on self-attention to process sequences in parallel and capture long-range dependencies.
+Fine-tuning allows a pretrained model to adapt to a new dataset with relatively little data by updating its weights from
+a pre-initialized state. Text generation uses the model to autoregressively predict subsequent tokens given a prompt.
+
+Self-attention computes pairwise interactions between all positions in a
+sequence, enabling the model to weigh the relevance of words regardless of their
+distance. Stacking multiple attention layers yields powerful contextual
+representations. Transformers eschew recurrence entirely, allowing them to be
+parallelized efficiently on modern hardware while still modelling complex
+relationships within text.

--- a/deep_learning/cnn_models.py
+++ b/deep_learning/cnn_models.py
@@ -1,0 +1,47 @@
+"""Convolutional neural network utilities using PyTorch."""
+
+import torch
+from torch import nn
+
+
+class ResidualBlock(nn.Module):
+    def __init__(self, in_channels: int, out_channels: int, stride: int = 1):
+        super().__init__()
+        self.conv1 = nn.Conv2d(in_channels, out_channels, kernel_size=3, stride=stride, padding=1, bias=False)
+        self.bn1 = nn.BatchNorm2d(out_channels)
+        self.conv2 = nn.Conv2d(out_channels, out_channels, kernel_size=3, padding=1, bias=False)
+        self.bn2 = nn.BatchNorm2d(out_channels)
+        self.downsample = None
+        if stride != 1 or in_channels != out_channels:
+            self.downsample = nn.Sequential(
+                nn.Conv2d(in_channels, out_channels, kernel_size=1, stride=stride, bias=False),
+                nn.BatchNorm2d(out_channels),
+            )
+        self.relu = nn.ReLU(inplace=True)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        identity = x
+        out = self.relu(self.bn1(self.conv1(x)))
+        out = self.bn2(self.conv2(out))
+        if self.downsample is not None:
+            identity = self.downsample(x)
+        out += identity
+        return self.relu(out)
+
+
+class SimpleResNet(nn.Module):
+    """A tiny ResNet-like model for image classification."""
+
+    def __init__(self, in_channels: int, num_classes: int = 10):
+        super().__init__()
+        self.layer1 = ResidualBlock(in_channels, 64)
+        self.layer2 = ResidualBlock(64, 128, stride=2)
+        self.pool = nn.AdaptiveAvgPool2d((1, 1))
+        self.fc = nn.Linear(128, num_classes)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.layer1(x)
+        x = self.layer2(x)
+        x = self.pool(x)
+        x = torch.flatten(x, 1)
+        return self.fc(x)

--- a/deep_learning/cnn_models.py
+++ b/deep_learning/cnn_models.py
@@ -17,7 +17,7 @@ class ResidualBlock(nn.Module):
                 nn.Conv2d(in_channels, out_channels, kernel_size=1, stride=stride, bias=False),
                 nn.BatchNorm2d(out_channels),
             )
-        self.relu = nn.ReLU(inplace=True)
+        self.relu = nn.ReLU()
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         identity = x

--- a/deep_learning/gan_models.py
+++ b/deep_learning/gan_models.py
@@ -1,0 +1,36 @@
+"""Simple GAN architecture using PyTorch."""
+
+import torch
+from torch import nn
+
+
+class Generator(nn.Module):
+    def __init__(self, noise_dim: int = 100, img_shape: int = 784):
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Linear(noise_dim, 256),
+            nn.ReLU(True),
+            nn.Linear(256, 512),
+            nn.ReLU(True),
+            nn.Linear(512, img_shape),
+            nn.Tanh(),
+        )
+
+    def forward(self, z: torch.Tensor) -> torch.Tensor:
+        return self.net(z)
+
+
+class Discriminator(nn.Module):
+    def __init__(self, img_shape: int = 784):
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Linear(img_shape, 512),
+            nn.LeakyReLU(0.2, inplace=True),
+            nn.Linear(512, 256),
+            nn.LeakyReLU(0.2, inplace=True),
+            nn.Linear(256, 1),
+            nn.Sigmoid(),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.net(x)

--- a/deep_learning/gan_models.py
+++ b/deep_learning/gan_models.py
@@ -9,7 +9,7 @@ class Generator(nn.Module):
         super().__init__()
         self.net = nn.Sequential(
             nn.Linear(noise_dim, 256),
-            nn.ReLU(True),
+            nn.ReLU(),
             nn.Linear(256, 512),
             nn.ReLU(True),
             nn.Linear(512, img_shape),

--- a/deep_learning/gnn_models.py
+++ b/deep_learning/gnn_models.py
@@ -1,0 +1,66 @@
+"""Simple graph neural network layers using PyTorch."""
+
+import torch
+from torch import nn
+
+
+def normalize_adjacency(adj: torch.Tensor) -> torch.Tensor:
+    """Return symmetrically normalized adjacency matrix."""
+    rowsum = adj.sum(1)
+    d_inv_sqrt = torch.pow(rowsum, -0.5)
+    d_inv_sqrt[torch.isinf(d_inv_sqrt)] = 0.0
+    d_mat_inv_sqrt = torch.diag(d_inv_sqrt)
+    return d_mat_inv_sqrt @ adj @ d_mat_inv_sqrt
+
+
+class GCNLayer(nn.Module):
+    def __init__(self, in_features: int, out_features: int):
+        super().__init__()
+        self.linear = nn.Linear(in_features, out_features)
+
+    def forward(self, x: torch.Tensor, adj: torch.Tensor) -> torch.Tensor:
+        adj_norm = normalize_adjacency(adj)
+        x = adj_norm @ x
+        return self.linear(x)
+
+
+class GATLayer(nn.Module):
+    def __init__(self, in_features: int, out_features: int, heads: int = 1):
+        super().__init__()
+        self.heads = heads
+        self.linear = nn.Linear(in_features, out_features * heads, bias=False)
+        self.attn = nn.Parameter(torch.Tensor(1, heads, out_features * 2))
+        nn.init.xavier_uniform_(self.attn)
+
+    def forward(self, x: torch.Tensor, adj: torch.Tensor) -> torch.Tensor:
+        h = self.linear(x)
+        N = h.size(0)
+        h = h.view(N, self.heads, -1)
+        a_input = torch.cat([h.repeat(1, 1, N).view(N, N, self.heads, -1),
+                             h.repeat(N, 1, 1)], dim=-1)
+        e = (a_input * self.attn).sum(-1)
+        e = torch.where(adj > 0, e, torch.full_like(e, -9e15))
+        attention = torch.softmax(e, dim=1)
+        h_prime = torch.einsum("ijh,jhd->ihd", attention, h)
+        return h_prime.reshape(N, -1)
+
+
+class GraphSAGELayer(nn.Module):
+    """GraphSAGE layer with mean, sum or max aggregation."""
+
+    def __init__(self, in_features: int, out_features: int, agg: str = "mean"):
+        super().__init__()
+        self.linear = nn.Linear(in_features * 2, out_features)
+        self.agg = agg
+
+    def forward(self, x: torch.Tensor, adj: torch.Tensor) -> torch.Tensor:
+        if self.agg == "mean":
+            neigh = torch.matmul(adj, x) / (adj.sum(1, keepdim=True) + 1e-10)
+        elif self.agg == "sum":
+            neigh = torch.matmul(adj, x)
+        elif self.agg == "max":
+            neigh, _ = torch.max(adj.unsqueeze(-1) * x.unsqueeze(0), dim=1)
+        else:
+            raise ValueError("Unknown aggregation: {}".format(self.agg))
+        h = torch.cat([x, neigh], dim=1)
+        return self.linear(h)

--- a/deep_learning/reinforcement_learning.py
+++ b/deep_learning/reinforcement_learning.py
@@ -1,0 +1,74 @@
+"""Basic reinforcement learning helpers using Q-learning."""
+
+import numpy as np
+import torch
+from torch import nn
+
+
+def epsilon_greedy(q_values: np.ndarray, epsilon: float) -> int:
+    """Select an action using epsilon-greedy policy."""
+    if np.random.rand() < epsilon:
+        return np.random.randint(len(q_values))
+    return int(np.argmax(q_values))
+
+
+def q_learning(env, episodes: int = 1000, alpha: float = 0.1, gamma: float = 0.99, epsilon: float = 0.1):
+    """Run a simple Q-learning loop for a Gym-like environment."""
+    q_table = np.zeros((env.observation_space.n, env.action_space.n))
+    for _ in range(episodes):
+        state = env.reset()
+        done = False
+        while not done:
+            action = epsilon_greedy(q_table[state], epsilon)
+            next_state, reward, done, _ = env.step(action)
+            best_next = np.max(q_table[next_state])
+            q_table[state, action] += alpha * (reward + gamma * best_next - q_table[state, action])
+            state = next_state
+    return q_table
+
+
+class DQN(nn.Module):
+    """A minimal Deep Q-Network."""
+
+    def __init__(self, state_dim: int, action_dim: int, hidden: int = 128):
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Linear(state_dim, hidden),
+            nn.ReLU(),
+            nn.Linear(hidden, hidden),
+            nn.ReLU(),
+            nn.Linear(hidden, action_dim),
+        )
+
+    def forward(self, x):
+        return self.net(x)
+
+
+def dqn_learning(env, episodes: int = 500, gamma: float = 0.99, epsilon: float = 0.1, lr: float = 1e-3):
+    """Train a simple DQN on ``env`` and return the trained network."""
+    state_dim = env.observation_space.shape[0]
+    action_dim = env.action_space.n
+    q_net = DQN(state_dim, action_dim)
+    optimizer = torch.optim.Adam(q_net.parameters(), lr=lr)
+    loss_fn = nn.MSELoss()
+
+    for _ in range(episodes):
+        state = env.reset()
+        done = False
+        state = torch.tensor(state, dtype=torch.float32)
+        while not done:
+            if np.random.rand() < epsilon:
+                action = env.action_space.sample()
+            else:
+                with torch.no_grad():
+                    action = int(torch.argmax(q_net(state)).item())
+            next_state, reward, done, _ = env.step(action)
+            next_state_t = torch.tensor(next_state, dtype=torch.float32)
+            target = reward + gamma * (0.0 if done else torch.max(q_net(next_state_t)).item())
+            q_value = q_net(state)[action]
+            loss = loss_fn(q_value, torch.tensor(target))
+            optimizer.zero_grad()
+            loss.backward()
+            optimizer.step()
+            state = next_state_t
+    return q_net

--- a/deep_learning/rnn_helpers.py
+++ b/deep_learning/rnn_helpers.py
@@ -9,7 +9,7 @@ class SimpleRNNModel(nn.Module):
         self.rnn = nn.RNN(input_size, hidden_size, num_layers, batch_first=True)
         self.fc = nn.Linear(hidden_size, output_size)
 
-    def forward(self, x):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         out, _ = self.rnn(x)
         return self.fc(out[:, -1, :])
 

--- a/deep_learning/rnn_helpers.py
+++ b/deep_learning/rnn_helpers.py
@@ -1,0 +1,38 @@
+"""Utilities for building simple RNN and LSTM models with PyTorch."""
+
+from torch import nn
+
+
+class SimpleRNNModel(nn.Module):
+    def __init__(self, input_size: int, hidden_size: int, num_layers: int, output_size: int):
+        super().__init__()
+        self.rnn = nn.RNN(input_size, hidden_size, num_layers, batch_first=True)
+        self.fc = nn.Linear(hidden_size, output_size)
+
+    def forward(self, x):
+        out, _ = self.rnn(x)
+        return self.fc(out[:, -1, :])
+
+
+class LSTMModel(nn.Module):
+    def __init__(self, input_size: int, hidden_size: int, num_layers: int, output_size: int):
+        super().__init__()
+        self.lstm = nn.LSTM(input_size, hidden_size, num_layers, batch_first=True)
+        self.fc = nn.Linear(hidden_size, output_size)
+
+    def forward(self, x):
+        out, _ = self.lstm(x)
+        return self.fc(out[:, -1, :])
+
+
+class GRUModel(nn.Module):
+    """GRU-based sequence model."""
+
+    def __init__(self, input_size: int, hidden_size: int, num_layers: int, output_size: int):
+        super().__init__()
+        self.gru = nn.GRU(input_size, hidden_size, num_layers, batch_first=True)
+        self.fc = nn.Linear(hidden_size, output_size)
+
+    def forward(self, x):
+        out, _ = self.gru(x)
+        return self.fc(out[:, -1, :])

--- a/deep_learning/transformer_helpers.py
+++ b/deep_learning/transformer_helpers.py
@@ -1,0 +1,32 @@
+"""Utilities for working with Hugging Face transformers."""
+
+from transformers import AutoModelForCausalLM, AutoTokenizer, pipeline, Trainer, TrainingArguments
+
+
+def load_model_and_tokenizer(model_name: str):
+    """Load a pretrained causal LM and its tokenizer."""
+    tokenizer = AutoTokenizer.from_pretrained(model_name)
+    model = AutoModelForCausalLM.from_pretrained(model_name)
+    return model, tokenizer
+
+
+def generate_text(model, tokenizer, prompt: str, max_length: int = 50):
+    """Generate text continuation using a causal language model."""
+    inputs = tokenizer(prompt, return_tensors="pt")
+    outputs = model.generate(**inputs, max_length=max_length)
+    return tokenizer.decode(outputs[0], skip_special_tokens=True)
+
+
+def text_generation_pipeline(model_name: str):
+    """Return a simple text generation pipeline."""
+    return pipeline("text-generation", model=model_name)
+
+
+def fine_tune_text_classification(model_name: str, train_dataset, eval_dataset, epochs: int = 1):
+    """Fine-tune a transformer for text classification using Hugging Face Trainer."""
+    model = AutoModelForCausalLM.from_pretrained(model_name)
+    tokenizer = AutoTokenizer.from_pretrained(model_name)
+    args = TrainingArguments(output_dir="./tmp_trainer", num_train_epochs=epochs, logging_steps=10)
+    trainer = Trainer(model=model, args=args, train_dataset=train_dataset, eval_dataset=eval_dataset, tokenizer=tokenizer)
+    trainer.train()
+    return trainer

--- a/deep_learning/transformer_helpers.py
+++ b/deep_learning/transformer_helpers.py
@@ -26,6 +26,8 @@ def fine_tune_text_classification(model_name: str, train_dataset, eval_dataset, 
     """Fine-tune a transformer for text classification using Hugging Face Trainer."""
     model = AutoModelForSequenceClassification.from_pretrained(model_name)
     tokenizer = AutoTokenizer.from_pretrained(model_name)
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
     args = TrainingArguments(output_dir="./tmp_trainer", num_train_epochs=epochs, logging_steps=10)
     trainer = Trainer(model=model, args=args, train_dataset=train_dataset, eval_dataset=eval_dataset, tokenizer=tokenizer)
     trainer.train()

--- a/deep_learning/transformer_helpers.py
+++ b/deep_learning/transformer_helpers.py
@@ -24,7 +24,7 @@ def text_generation_pipeline(model_name: str):
 
 def fine_tune_text_classification(model_name: str, train_dataset, eval_dataset, epochs: int = 1):
     """Fine-tune a transformer for text classification using Hugging Face Trainer."""
-    model = AutoModelForCausalLM.from_pretrained(model_name)
+    model = AutoModelForSequenceClassification.from_pretrained(model_name)
     tokenizer = AutoTokenizer.from_pretrained(model_name)
     args = TrainingArguments(output_dir="./tmp_trainer", num_train_epochs=epochs, logging_steps=10)
     trainer = Trainer(model=model, args=args, train_dataset=train_dataset, eval_dataset=eval_dataset, tokenizer=tokenizer)

--- a/general/README_helpers.md
+++ b/general/README_helpers.md
@@ -1,0 +1,29 @@
+# helpers.py
+
+This module contains a variety of utility functions useful in day-to-day data science and software projects. The
+functions demonstrate core Python features such as decorators, comprehensions, and standard library modules.
+
+## Key Utilities
+
+- **`set_seed`** – sets the random seed for Python, NumPy and optionally PyTorch so that experiments are reproducible.
+- **`flatten_list`** – demonstrates list comprehensions by flattening a list of lists into a single list.
+- **`chunk_list`** – yields successive chunks from an iterable using a generator with the `yield` keyword.
+- **`download_file`** – shows how to stream a download with `requests` and write the bytes to disk in chunks.
+- **`timeit`** – an example of a decorator that measures execution time for any wrapped function.
+- **`dataframe_memory_usage`** – computes memory consumption of a `pandas` DataFrame in megabytes.
+- **`save_json` / `load_json`** – save Python objects to disk as JSON and read them back.
+- **`classification_report`** – wraps common scikit-learn metrics (accuracy, precision, recall, f1).
+- **`plot_confusion_matrix`** – visualises a confusion matrix using Matplotlib.
+
+## Python Syntax Notes
+
+The code uses type hints like `def set_seed(seed: int) -> None:` to clarify argument and return types. Decorators
+(`timeit`) employ `functools.wraps` to preserve metadata of the wrapped function. Comprehensions are used to create
+lists concisely, and context managers handle file operations in `download_file`, `save_json`, and `load_json`.
+
+## Underlying Concepts
+
+Reproducibility through seeding ensures that random operations (e.g., model training) yield the same results across
+runs. JSON serialization enables easy sharing of parameters or predictions. Accuracy, precision, recall and F1-score
+are fundamental metrics for evaluating classification models, while a confusion matrix provides a richer breakdown of
+true vs predicted labels.

--- a/general/README_manipulating_files.md
+++ b/general/README_manipulating_files.md
@@ -1,0 +1,26 @@
+# manipulating_files.py
+
+This script offers small helpers for common filesystem tasks using the `pathlib` module. It demonstrates iterating
+through directories, renaming files and reading or writing plain text.
+
+## Helper Functions
+
+- **`list_files_by_extension`** – returns all files in a directory that match a particular extension using `Path.glob`.
+- **`rename_files_with_prefix`** – prepends a prefix to every file name in a directory. The function loops over
+  `Path.iterdir()` and renames each path.
+- **`remove_files_by_extension`** – deletes files with a given extension, showing how to call `Path.unlink`.
+- **`count_lines`** – counts the number of lines in a file by iterating over it. Using a generator expression keeps
+  memory usage low.
+- **`read_text` / `write_text`** – simple wrappers around opening files with a context manager.
+
+## Syntax Highlights
+
+Each function uses type annotations to clarify argument types. The `for` loops illustrate typical iteration over
+`Path` objects. Reading and writing is done with the standard `open` function, ensuring files are closed properly via
+the `with` statement.
+
+## Concepts
+
+Understanding how to manipulate the filesystem is essential for automation scripts and data pipelines. Using
+`pathlib` provides an object-oriented approach that works across operating systems. Counting lines or removing files by
+pattern are everyday tasks in data preprocessing and log management.

--- a/general/helpers.py
+++ b/general/helpers.py
@@ -1,0 +1,107 @@
+import json
+import os
+import random
+from functools import wraps
+from time import time
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import matplotlib.pyplot as plt
+import requests
+from sklearn.metrics import (accuracy_score, f1_score,
+                             precision_score, recall_score,
+                             confusion_matrix)
+
+
+def set_seed(seed: int = 42) -> None:
+    """Set random seed for Python, NumPy and, if available, PyTorch."""
+    random.seed(seed)
+    np.random.seed(seed)
+    try:
+        import torch  # type: ignore
+        torch.manual_seed(seed)
+        torch.cuda.manual_seed_all(seed)
+    except Exception:
+        pass
+
+
+def flatten_list(nested_list):
+    """Flatten a nested list into a single list."""
+    return [item for sub in nested_list for item in sub]
+
+
+def chunk_list(iterable, chunk_size):
+    """Yield successive chunks from an iterable."""
+    for i in range(0, len(iterable), chunk_size):
+        yield iterable[i : i + chunk_size]
+
+
+def download_file(url: str, destination: str) -> None:
+    """Download a file from ``url`` to ``destination``."""
+    response = requests.get(url, stream=True)
+    response.raise_for_status()
+    with open(destination, "wb") as f:
+        for chunk in response.iter_content(chunk_size=8192):
+            f.write(chunk)
+
+
+def timeit(func):
+    """Decorator that prints the execution time of the function it wraps."""
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        start = time()
+        result = func(*args, **kwargs)
+        end = time()
+        print(f"{func.__name__} executed in {end - start:.2f}s")
+        return result
+
+    return wrapper
+
+
+def dataframe_memory_usage(df: pd.DataFrame) -> float:
+    """Return memory usage of a ``pandas`` DataFrame in megabytes."""
+    return df.memory_usage(deep=True).sum() / 1e6
+
+
+def save_json(data, path: str, **kwargs) -> None:
+    """Save a Python object as a JSON file."""
+    with open(path, "w") as f:
+        json.dump(data, f, **kwargs)
+
+
+def load_json(path: str):
+    """Load a JSON file and return the corresponding Python object."""
+    with open(path) as f:
+        return json.load(f)
+
+
+def classification_report(y_true, y_pred) -> dict:
+    """Return a dictionary with common classification metrics."""
+    return {
+        "accuracy": accuracy_score(y_true, y_pred),
+        "precision": precision_score(y_true, y_pred, average="weighted"),
+        "recall": recall_score(y_true, y_pred, average="weighted"),
+        "f1": f1_score(y_true, y_pred, average="weighted"),
+    }
+
+
+def plot_confusion_matrix(y_true, y_pred, labels=None):
+    """Plot and return a confusion matrix."""
+    cm = confusion_matrix(y_true, y_pred, labels=labels)
+    fig, ax = plt.subplots()
+    im = ax.imshow(cm, cmap="Blues")
+    ax.figure.colorbar(im, ax=ax)
+    ax.set_xlabel("Predicted")
+    ax.set_ylabel("True")
+    if labels is not None:
+        ax.set_xticks(range(len(labels)))
+        ax.set_yticks(range(len(labels)))
+        ax.set_xticklabels(labels)
+        ax.set_yticklabels(labels)
+    for i in range(cm.shape[0]):
+        for j in range(cm.shape[1]):
+            ax.text(j, i, cm[i, j], ha="center", va="center", color="black")
+    plt.tight_layout()
+    return fig, ax

--- a/general/helpers.py
+++ b/general/helpers.py
@@ -22,7 +22,7 @@ def set_seed(seed: int = 42) -> None:
         import torch  # type: ignore
         torch.manual_seed(seed)
         torch.cuda.manual_seed_all(seed)
-    except Exception:
+    except ImportError:
         pass
 
 

--- a/general/manipulating_files.py
+++ b/general/manipulating_files.py
@@ -1,0 +1,38 @@
+import os
+from pathlib import Path
+
+
+def list_files_by_extension(directory: str, extension: str):
+    """Return a list of file paths with a given extension in ``directory``."""
+    return [str(f) for f in Path(directory).glob(f"*{extension}")]
+
+
+def rename_files_with_prefix(directory: str, prefix: str) -> None:
+    """Rename files in ``directory`` by prepending ``prefix`` to each name."""
+    for path in Path(directory).iterdir():
+        if path.is_file():
+            path.rename(path.with_name(prefix + path.name))
+
+
+def remove_files_by_extension(directory: str, extension: str) -> None:
+    """Delete all files with ``extension`` in ``directory``."""
+    for path in Path(directory).glob(f"*{extension}"):
+        path.unlink()
+
+
+def count_lines(path: str) -> int:
+    """Count the number of lines in a text file."""
+    with open(path) as f:
+        return sum(1 for _ in f)
+
+
+def read_text(path: str) -> str:
+    """Read an entire text file and return its contents."""
+    with open(path) as f:
+        return f.read()
+
+
+def write_text(path: str, text: str) -> None:
+    """Write ``text`` to ``path``, overwriting any existing content."""
+    with open(path, "w") as f:
+        f.write(text)

--- a/machine_learning/Preprocessing.py
+++ b/machine_learning/Preprocessing.py
@@ -1,0 +1,42 @@
+import pandas as pd
+from sklearn.model_selection import train_test_split
+from sklearn.preprocessing import OneHotEncoder, StandardScaler
+
+
+def split_features_labels(df: pd.DataFrame, target: str):
+    """Split a DataFrame into features and target."""
+    X = df.drop(columns=[target])
+    y = df[target]
+    return X, y
+
+
+def basic_train_test_split(df: pd.DataFrame, target: str, test_size: float = 0.2, random_state: int = 42):
+    """Split DataFrame into train and test sets."""
+    X, y = split_features_labels(df, target)
+    return train_test_split(X, y, test_size=test_size, random_state=random_state)
+
+
+def scale_numeric_features(X_train: pd.DataFrame, X_test: pd.DataFrame):
+    """Scale numeric features with ``StandardScaler``."""
+    scaler = StandardScaler()
+    X_train_scaled = scaler.fit_transform(X_train)
+    X_test_scaled = scaler.transform(X_test)
+    return X_train_scaled, X_test_scaled, scaler
+
+
+def encode_categorical_features(X_train: pd.DataFrame, X_test: pd.DataFrame, categorical_columns):
+    """One-hot encode categorical columns and return transformed DataFrames."""
+    encoder = OneHotEncoder(handle_unknown="ignore", sparse=False)
+    train_encoded = encoder.fit_transform(X_train[categorical_columns])
+    test_encoded = encoder.transform(X_test[categorical_columns])
+    X_train_rest = X_train.drop(columns=categorical_columns).reset_index(drop=True)
+    X_test_rest = X_test.drop(columns=categorical_columns).reset_index(drop=True)
+    X_train_processed = pd.concat(
+        [X_train_rest, pd.DataFrame(train_encoded, columns=encoder.get_feature_names_out())],
+        axis=1,
+    )
+    X_test_processed = pd.concat(
+        [X_test_rest, pd.DataFrame(test_encoded, columns=encoder.get_feature_names_out())],
+        axis=1,
+    )
+    return X_train_processed, X_test_processed, encoder

--- a/machine_learning/Preprocessing.py
+++ b/machine_learning/Preprocessing.py
@@ -26,7 +26,7 @@ def scale_numeric_features(X_train: pd.DataFrame, X_test: pd.DataFrame):
 
 def encode_categorical_features(X_train: pd.DataFrame, X_test: pd.DataFrame, categorical_columns):
     """One-hot encode categorical columns and return transformed DataFrames."""
-    encoder = OneHotEncoder(handle_unknown="ignore", sparse=False)
+    encoder = OneHotEncoder(handle_unknown="ignore", sparse_output=False)
     train_encoded = encoder.fit_transform(X_train[categorical_columns])
     test_encoded = encoder.transform(X_test[categorical_columns])
     X_train_rest = X_train.drop(columns=categorical_columns).reset_index(drop=True)

--- a/machine_learning/README_Preprocessing.md
+++ b/machine_learning/README_Preprocessing.md
@@ -1,0 +1,26 @@
+# Preprocessing.py
+
+This module gathers basic preprocessing utilities using `pandas` and `scikit-learn`. Proper preparation of data is
+crucial for any machine learning workflow, and these helpers cover the common steps of splitting, scaling, and encoding.
+
+## Functions
+
+- **`split_features_labels`** – separates a DataFrame into feature matrix `X` and target vector `y`.
+- **`basic_train_test_split`** – wraps `train_test_split` to obtain train and test sets from a DataFrame.
+- **`scale_numeric_features`** – fits a `StandardScaler` on the training data and applies it to both train and test
+  sets, returning the transformed arrays and the fitted scaler.
+- **`encode_categorical_features`** – performs one-hot encoding on specified categorical columns using
+  `OneHotEncoder`, then concatenates the encoded features back to the rest of the DataFrame.
+
+## Python Usage
+
+The functions rely on pandas for DataFrame manipulation. Notice the use of keyword defaults (`test_size=0.2`) which let
+users override behaviour. Returning multiple values (for example, `(X_train_processed, X_test_processed, encoder)`)
+illustrates how Python supports tuple unpacking.
+
+## Theory
+
+Data should be split into training and testing sets to evaluate models on unseen data. Standardization scales features
+to zero mean and unit variance, a common prerequisite for many algorithms that assume similarly scaled inputs. One-hot
+encoding converts categorical variables into numerical binary features so that algorithms can treat each category as a
+separate dimension.

--- a/machine_learning/README_hyperparameter_tuning.md
+++ b/machine_learning/README_hyperparameter_tuning.md
@@ -1,0 +1,23 @@
+# hyperparameter_tuning.py
+
+Machine learning models often expose numerous hyperparameters that control training behaviour. This script wraps
+scikit-learn's `GridSearchCV` and `RandomizedSearchCV` to help find good parameter combinations.
+
+## Helpers
+
+- **`grid_search`** – exhaustively explores the provided `param_grid` for a model using cross-validation.
+- **`random_search`** – samples combinations from `param_distributions` for a fixed number of iterations.
+
+Both functions print the best parameters and return the fitted search object so you can inspect results further.
+
+## Python Features
+
+Notice how `**kwargs` are forwarded to scikit-learn classes via direct instantiation. `f"Best score: {search.best_score_}"`
+illustrates f-strings for formatting. Type hints like `cv: int = 5` document expected argument types and defaults.
+
+## Theory
+
+Hyperparameters control aspects such as regularization strength or tree depth. Grid search systematically evaluates all
+possible combinations but can be expensive. Random search selects random combinations, often reaching good solutions
+faster when the hyperparameter space is large. Cross-validation averages results across folds to estimate generalization
+performance.

--- a/machine_learning/README_supervised_learning.md
+++ b/machine_learning/README_supervised_learning.md
@@ -1,0 +1,23 @@
+# supervised_learning.py
+
+This file provides lightweight wrappers around scikit-learn classifiers for quick experimentation.
+
+## Provided Functions
+
+- **`train_logistic_regression`** – constructs a `LogisticRegression` model and fits it on the data.
+  Logistic regression models the log-odds of the target class as a linear function of the features.
+- **`train_random_forest`** – trains a `RandomForestClassifier`, which combines many decision trees to reduce variance
+  and capture nonlinear relationships.
+- **`evaluate_model`** – runs prediction on test data and prints accuracy.
+
+## Python Highlights
+
+`**kwargs` let callers pass any scikit-learn options, such as `C` for regularization or `n_estimators` for forest size.
+The `evaluate_model` function uses f-strings for formatting the accuracy with four decimal places.
+
+## Theoretical Background
+
+Logistic regression is a linear model that uses the sigmoid function to map inputs to probabilities. It is widely used
+for binary classification. Random forests are an ensemble method where each tree is built on a bootstrap sample of the
+training data; predictions are averaged to provide robustness. Accuracy measures the proportion of correct predictions
+and serves as a baseline metric for classification tasks.

--- a/machine_learning/README_unsupervised_learning.md
+++ b/machine_learning/README_unsupervised_learning.md
@@ -1,0 +1,21 @@
+# unsupervised_learning.py
+
+The unsupervised learning helpers cover clustering and dimensionality reduction techniques implemented in scikit-learn.
+
+## Functions
+
+- **`run_kmeans`** – performs k-means clustering, returning the fitted model and the labels assigned to each point.
+- **`run_pca`** – reduces the dimensionality of data with Principal Component Analysis and returns the transformed
+  components.
+- **`run_tsne`** – computes a nonlinear embedding using t-SNE, useful for visualising high-dimensional data.
+
+## Python Notes
+
+The functions rely on scikit-learn estimators. Type hints specify the expected argument types and default parameter
+values. Returning both the estimator object and the transformed data allows for later inspection or re-use.
+
+## Theory
+
+K-means partitions observations into clusters by minimizing within-cluster variance. PCA projects data onto orthogonal
+axes that capture maximum variance, enabling compression and noise reduction. t-SNE maps data into a lower-dimensional
+space while preserving local structure, commonly used for visualising embeddings.

--- a/machine_learning/hyperparameter_tuning.py
+++ b/machine_learning/hyperparameter_tuning.py
@@ -1,0 +1,19 @@
+from sklearn.model_selection import GridSearchCV, RandomizedSearchCV
+
+
+def grid_search(model, param_grid, X_train, y_train, cv: int = 5, scoring=None):
+    """Perform ``GridSearchCV`` and return the fitted object."""
+    search = GridSearchCV(model, param_grid, cv=cv, scoring=scoring)
+    search.fit(X_train, y_train)
+    print(f"Best parameters: {search.best_params_}")
+    print(f"Best score: {search.best_score_}")
+    return search
+
+
+def random_search(model, param_distributions, X_train, y_train, n_iter: int = 10, cv: int = 5, scoring=None):
+    """Perform ``RandomizedSearchCV`` and return the fitted object."""
+    search = RandomizedSearchCV(model, param_distributions, n_iter=n_iter, cv=cv, scoring=scoring)
+    search.fit(X_train, y_train)
+    print(f"Best parameters: {search.best_params_}")
+    print(f"Best score: {search.best_score_}")
+    return search

--- a/machine_learning/supervised_learning.py
+++ b/machine_learning/supervised_learning.py
@@ -1,0 +1,25 @@
+from sklearn.linear_model import LogisticRegression
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.metrics import accuracy_score
+
+
+def train_logistic_regression(X_train, y_train, **kwargs):
+    """Train a ``LogisticRegression`` model."""
+    model = LogisticRegression(**kwargs)
+    model.fit(X_train, y_train)
+    return model
+
+
+def train_random_forest(X_train, y_train, **kwargs):
+    """Train a ``RandomForestClassifier`` model."""
+    model = RandomForestClassifier(**kwargs)
+    model.fit(X_train, y_train)
+    return model
+
+
+def evaluate_model(model, X_test, y_test):
+    """Predict on ``X_test`` and return predictions and accuracy."""
+    preds = model.predict(X_test)
+    acc = accuracy_score(y_test, preds)
+    print(f"Accuracy: {acc:.4f}")
+    return preds, acc

--- a/machine_learning/unsupervised_learning.py
+++ b/machine_learning/unsupervised_learning.py
@@ -1,0 +1,24 @@
+from sklearn.cluster import KMeans
+from sklearn.decomposition import PCA
+from sklearn.manifold import TSNE
+
+
+def run_kmeans(X, n_clusters: int = 8, random_state: int = 42):
+    """Cluster ``X`` using k-means and return the fitted model and labels."""
+    model = KMeans(n_clusters=n_clusters, random_state=random_state)
+    labels = model.fit_predict(X)
+    return model, labels
+
+
+def run_pca(X, n_components: int = 2):
+    """Reduce dimensionality of ``X`` using PCA."""
+    pca = PCA(n_components=n_components)
+    components = pca.fit_transform(X)
+    return pca, components
+
+
+def run_tsne(X, n_components: int = 2, random_state: int = 42):
+    """Run t-SNE on ``X`` and return the embedding."""
+    tsne = TSNE(n_components=n_components, random_state=random_state)
+    embedding = tsne.fit_transform(X)
+    return tsne, embedding

--- a/machine_learning/unsupervised_learning.py
+++ b/machine_learning/unsupervised_learning.py
@@ -5,7 +5,7 @@ from sklearn.manifold import TSNE
 
 def run_kmeans(X, n_clusters: int = 8, random_state: int = 42):
     """Cluster ``X`` using k-means and return the fitted model and labels."""
-    model = KMeans(n_clusters=n_clusters, random_state=random_state)
+    model = KMeans(n_clusters=n_clusters, random_state=random_state, n_init=10)
     labels = model.fit_predict(X)
     return model, labels
 


### PR DESCRIPTION
## Summary
- expand theory explanations for PyTorch and TensorFlow helper scripts
- elaborate on CNN, GAN, and GNN helper theory
- extend RNN, reinforcement learning and transformer README sections

## Testing
- `python -m py_compile general/helpers.py general/manipulating_files.py machine_learning/Preprocessing.py machine_learning/hyperparameter_tuning.py machine_learning/supervised_learning.py machine_learning/unsupervised_learning.py deep_learning/transformer_helpers.py deep_learning/gnn_models.py deep_learning/rnn_helpers.py deep_learning/reinforcement_learning.py deep_learning/cnn_models.py deep_learning/gan_models.py`

------
https://chatgpt.com/codex/tasks/task_e_68701b27957c8324a8a37a7f78b71a5f